### PR TITLE
feat(external schematic): add Prettier to ng add

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 ![npm (scoped)](https://img.shields.io/npm/v/@ng-seattle/community-schematics)
-![npm (tag)](https://img.shields.io/npm/v/@ng-seattle/community-schematics/next)  
+![npm (tag)](https://img.shields.io/npm/v/@ng-seattle/community-schematics/next)
 
 # Community Schematics
 
@@ -26,6 +26,17 @@ Then use `ng add` and follow the prompts to setup the project and you're good to
 ```bash
 $ ng add @ng-seattle/community-schematics
 ```
+
+### External Schematics Used
+
+Depending on the options you select during the `ng add` process, the following external `ng add` schematics can be invoked:
+
+- [@angular/material](https://github.com/angular/components/) (This is always invoked)
+- [@azure/ng-deploy](https://github.com/Azure/ng-deploy-azure)
+- [angular-cli-ghpages](https://github.com/angular-schule/angular-cli-ghpages)
+- [@netlify-builder/deploy](https://github.com/ngx-builders/netlify-builder)
+- [@zeit/ng-deploy](https://github.com/zeit/ng-deploy-now)
+- [@schuchard/prettier](https://github.com/schuchard/prettier-schematic)
 
 ## Future Feature Plans
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -518,14 +518,16 @@
       }
     },
     "@types/jasmine": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.3.16.tgz",
-      "integrity": "sha512-Nveep4zKGby8uIvG2AEUyYOwZS8uVeHK9TgbuWYSawUDDdIgfhCKz28QzamTo//Jk7Ztt9PO3f+vzlB6a4GV1Q=="
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.3.9.tgz",
+      "integrity": "sha512-vw3VyFPa9mlba6NZPBZC3q2Zrnkgy5xuCVI43/tTLX6umdYrYvcFtQUKi2zH3PjFZQ9XCxNM/NMrM9uk8TPOzg==",
+      "dev": true
     },
     "@types/node": {
-      "version": "8.10.51",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.51.tgz",
-      "integrity": "sha512-cArrlJp3Yv6IyFT/DYe+rlO8o3SIHraALbBW/+CcCYW/a9QucpLI+n2p4sRxAvl2O35TiecpX2heSZtJjvEO+Q=="
+      "version": "8.0.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.31.tgz",
+      "integrity": "sha512-R+LdMJHJQwRd/Ca0Nr5KnwbSWHxTD3DWz4ivqoPeNH+YPcuirMWK+Ti9Mx32jOecmPhHOCd+6CefU5e1eVq2Ew==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -694,7 +696,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -755,6 +758,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1018,7 +1022,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "conventional-changelog-angular": {
       "version": "1.6.6",
@@ -1597,7 +1602,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "get-stdin": {
       "version": "7.0.0",
@@ -1656,6 +1662,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
       "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1845,6 +1852,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1853,7 +1861,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
@@ -2085,18 +2094,20 @@
       "dev": true
     },
     "jasmine": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.4.0.tgz",
-      "integrity": "sha512-sR9b4n+fnBFDEd7VS2el2DeHgKcPiMVn44rtKFumq9q7P/t8WrxsVIZPob4UDdgcDNCwyDqwxCt4k9TDRmjPoQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.3.1.tgz",
+      "integrity": "sha512-/vU3/H7U56XsxIXHwgEuWpCgQ0bRi2iiZeUpx7Nqo8n1TpoDHfZhkPIc7CO8I4pnMzYsi3XaSZEiy8cnTfujng==",
+      "dev": true,
       "requires": {
-        "glob": "^7.1.3",
-        "jasmine-core": "~3.4.0"
+        "glob": "^7.0.6",
+        "jasmine-core": "~3.3.0"
       }
     },
     "jasmine-core": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.4.0.tgz",
-      "integrity": "sha512-HU/YxV4i6GcmiH4duATwAbJQMlE0MsDIR5XmSVxURxKHn3aGAdbY1/ZJFmVRbKtnLwIxxMJD7gYaPsypcbYimg=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.3.0.tgz",
+      "integrity": "sha512-3/xSmG/d35hf80BEN66Y6g9Ca5l/Isdeg/j6zvbTYlTzeKinzmaTM4p9am5kYqOmE05D7s1t8FGjzdSnbUbceA==",
+      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -2324,6 +2335,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -2507,6 +2519,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -2608,7 +2621,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-key": {
       "version": "2.0.1",
@@ -3426,7 +3440,8 @@
     "typescript": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g=="
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "dev": true
     },
     "union-value": {
       "version": "1.0.1",
@@ -3540,7 +3555,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -29,19 +29,19 @@
   "dependencies": {
     "@angular-devkit/core": "^8.2.0",
     "@angular-devkit/schematics": "^8.2.0",
-    "@schematics/angular": "^8.2.0",
-    "@types/jasmine": "^3.3.9",
-    "@types/node": "^8.0.31",
-    "jasmine": "^3.3.1",
-    "typescript": "~3.5.3"
+    "@schematics/angular": "^8.2.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",
     "@commitlint/config-conventional": "^8.2.0",
     "@semantic-release/changelog": "^3.0.6",
     "@semantic-release/git": "^8.0.0",
+    "@types/jasmine": "^3.3.9",
+    "@types/node": "^8.0.31",
     "cz-conventional-changelog": "^3.0.2",
-    "husky": "^3.1.0"
+    "husky": "^3.1.0",
+    "jasmine": "^3.3.1",
+    "typescript": "~3.5.3"
   },
   "config": {
     "commitizen": {

--- a/src/ng-add-setup-project/index.ts
+++ b/src/ng-add-setup-project/index.ts
@@ -24,6 +24,7 @@ export function ngAddSetupProject(options: Schema): Rule {
       options.meetupName.length > 0 ? addMeetup(options) : noop(),
       addDeployment(options.deployment),
       addMaterial(options),
+      options.addPrettier ? addPrettier() : noop(),
       addFiles(options),
       updateScripts(options)
     ]);
@@ -38,6 +39,16 @@ function addMaterial(options: Schema): Rule {
     return externalSchematic('@angular/material', 'install', {
       options
     });
+  };
+}
+
+/**
+ * A rule factory that adds Prettier to the project
+ * @param options The options passed down to the schematic
+ */
+function addPrettier(): Rule {
+  return (_tree: Tree, _context: SchematicContext) => {
+    return externalSchematic('@schuchard/prettier', 'add', {});
   };
 }
 

--- a/src/ng-add/index.ts
+++ b/src/ng-add/index.ts
@@ -28,6 +28,10 @@ export default function(options: Schema): Rule {
 function prepareDependencies(options: Schema): Rule {
   const deps = ['@angular/material'];
 
+  if (options.addPrettier) {
+    deps.push('@schuchard/prettier');
+  }
+
   switch (options.deployment) {
     case 'Azure':
       deps.push('@azure/ng-deploy');

--- a/src/ng-add/schema.json
+++ b/src/ng-add/schema.json
@@ -38,6 +38,12 @@
       "default": "None",
       "enum": ["Azure", "Now", "Netlify", "Github Pages", "None"],
       "x-prompt": "Do you want to deploy your site with any of the following providers?"
+    },
+    "addPrettier": {
+      "description:": "Whether or not Prettier should be added to the project",
+      "type": "boolean",
+      "x-prompt": "Would you like to setup Prettier in your project?",
+      "default": [true]
     }
   },
   "required": ["orgName"],

--- a/src/ng-add/schema.model.ts
+++ b/src/ng-add/schema.model.ts
@@ -5,4 +5,5 @@ export interface Schema {
   pastTalks: string;
   twitter: string;
   deployment: 'Azure' | 'Github Pages' | 'Netlify' | 'Now' | 'None';
+  addPrettier: boolean;
 }


### PR DESCRIPTION
This change prompts the user to add Prettier to their project when executing the `ng add` command. If the user chooses yes, it installs and calls [@schuchard/prettier](https://github.c
om/schuchard/prettier-schematic).

Closes #10