### PR TITLE
fix(dependencies): keep dependencies targeted at Angular 8

### DIFF
--- a/src/ng-add/index.ts
+++ b/src/ng-add/index.ts
@@ -5,7 +5,7 @@ import {
   chain
 } from '@angular-devkit/schematics';
 import { Schema } from './schema.model';
-import { addPackageJsonDependencies } from '../utils/npmjs';
+import { addPackageJsonDependencies, JsonDependency } from '../utils/npmjs';
 import {
   NodePackageInstallTask,
   RunSchematicTask
@@ -26,7 +26,9 @@ export default function(options: Schema): Rule {
  * @param options The options the user selected
  */
 function prepareDependencies(options: Schema): Rule {
-  const deps = ['@angular/material'];
+  const deps: JsonDependency[] = [
+    { name: '@angular/material', version: '^8.2.3' }
+  ];
 
   if (options.addPrettier) {
     deps.push('@schuchard/prettier');


### PR DESCRIPTION
This change maintains compatibility with Angular 8 until support for Angular 9 is merged in.
Primarily this adds the ability to specify which version of a dependency added by `ng-add` is used. This is utilized to ensure that Angular Material v8 is installed, instead of v9.